### PR TITLE
Sending the Valid_Prefix

### DIFF
--- a/src/Signature.php
+++ b/src/Signature.php
@@ -199,7 +199,7 @@ class Signature
         if ($addKey) {
             // Note: The Key (filename) will need to be populated with JS on upload
             // if anything other than the filename is wanted.
-            $inputs['key'] = $this->options['default_filename'];
+            $inputs['key'] = $this->options['valid_prefix'].$this->options['default_filename'];
         }
 
         return $inputs;


### PR DESCRIPTION
If you set a Prefix on the policy, you need to set it on the form in the key value. if the prefix is "myDirectoty/" the form must be:

 <input type="hidden" name="key" value="myDirectoty/${filename}"/>