### PR TITLE
allow php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php" : ">=7.2",
+        "php" : ">=7.2 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
This allows PHP 8.0 in the composer.json. The tests run ok, and I haven't had any problems using 8.0 in production ( yet :) )